### PR TITLE
feat: add RootLayout to element-registry

### DIFF
--- a/packages/angular/src/lib/element-registry.ts
+++ b/packages/angular/src/lib/element-registry.ts
@@ -1,4 +1,4 @@
-import { View, LayoutBase, Page, Frame, AbsoluteLayout, ActivityIndicator, BottomNavigation, Button, ContentView, DatePicker, DockLayout, GridLayout, HtmlView, Image, Label, ListPicker, ListView, Placeholder, Progress, ProxyViewContainer, Repeater, ScrollView, SearchBar, SegmentedBar, SegmentedBarItem, Slider, StackLayout, FlexboxLayout, Switch, TabView, TabStrip, TabStripItem, TabContentItem, Tabs, TextField, TextView, TimePicker, WebView, WrapLayout, FormattedString, Span } from '@nativescript/core';
+import { View, LayoutBase, Page, Frame, AbsoluteLayout, ActivityIndicator, BottomNavigation, Button, ContentView, DatePicker, DockLayout, GridLayout, HtmlView, Image, Label, ListPicker, ListView, Placeholder, Progress, ProxyViewContainer, Repeater, ScrollView, SearchBar, SegmentedBar, SegmentedBarItem, Slider, StackLayout, FlexboxLayout, Switch, TabView, TabStrip, TabStripItem, TabContentItem, Tabs, TextField, TextView, TimePicker, WebView, WrapLayout, FormattedString, Span, RootLayout } from '@nativescript/core';
 
 export interface ViewClass {
 	new (): View;
@@ -183,6 +183,7 @@ registerElement('Placeholder', () => Placeholder);
 registerElement('Progress', () => Progress);
 registerElement('ProxyViewContainer', () => ProxyViewContainer);
 registerElement('Repeater', () => Repeater);
+registerElement('RootLayout', () => RootLayout);
 registerElement('ScrollView', () => ScrollView);
 registerElement('SearchBar', () => SearchBar);
 registerElement('SegmentedBar', () => SegmentedBar);


### PR DESCRIPTION
Adds `RootLayout` to element-registry. This is the changes required for `RootLayout` to work with Angular (https://github.com/NativeScript/NativeScript/pull/8980). This is dependent on Nativescript's `release/8.0.0` branch