### PR TITLE
fix(list-view): ensure templates are in a consistent state on itemLoa…

### DIFF
--- a/apps/nativescript-demo-ng/nativescript.config.ts
+++ b/apps/nativescript-demo-ng/nativescript.config.ts
@@ -1,16 +1,17 @@
 import { NativeScriptConfig } from '@nativescript/core';
 
 export default {
-	id: 'org.nativescript.demong',
-	appResourcesPath: 'App_Resources',
-	android: {
-		v8Flags: '--expose_gc',
+  id: 'org.nativescript.demong',
+  appResourcesPath: 'App_Resources',
+  android: {
+    v8Flags: '--expose_gc',
     markingMode: 'none',
     codeCache: true,
-    suppressCallJSMethodExceptions: false
+    suppressCallJSMethodExceptions: false,
+    discardUncaughtJsExceptions: true,
   },
   ios: {
-    discardUncaughtJsExceptions: false
+    discardUncaughtJsExceptions: true,
   },
-	appPath: 'src',
+  appPath: 'src',
 } as NativeScriptConfig;


### PR DESCRIPTION
…ding

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/angular/blob/master/DevelopmentWorkflow.md#running-the-tests
- [x] Tests for the changes are included.

## What is the current behavior?
ListView in core is kind of messy and ignores our default template, which is why it works fine without a custom key, but if you add a custom template key things start to break.

## What is the new behavior?
A couple of things:
1. we now use HostListener as it takes precedence over other events
2. we no longer `markForCheck` after `detach` because it will ignore `detach` anyway. Also it will always check at least once after the view is created anyway.
3. we also create a null view to avoid creating templates in inconsistent states (without context)
4. added `nativeElement` to setupItemView to make it easier for developers to access the view without using `itemLoading`.

Fixes #9.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

