### PR TITLE
fix(zone.js): correctly patch es6 classes

### DIFF
--- a/packages/zone-js/dist/core.ts
+++ b/packages/zone-js/dist/core.ts
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import { patchNativeScriptEventTarget } from './utils';
+import { patchClass, patchNativeScriptEventTarget } from './utils';
 
 function isPropertyWritable(propertyDesc: any) {
   if (!propertyDesc) {
@@ -48,4 +48,8 @@ Zone.__load_patch('nativescript_patchMethod', (global, Zone, api) => {
 
 Zone.__load_patch('nativescript_event_target_api', (g, z, api: any) => {
   api.patchNativeScriptEventTarget = patchNativeScriptEventTarget;
+});
+
+Zone.__load_patch('nativescript_patch_class_api', (g, z, api) => {
+  api.patchClass = (className: string) => patchClass(className, api);
 });

--- a/packages/zone-js/dist/index.ts
+++ b/packages/zone-js/dist/index.ts
@@ -1,4 +1,5 @@
 import './core';
+import './nativescript-globals';
 import './events';
 import './xhr';
 import './connectivity';

--- a/packages/zone-js/dist/nativescript-globals.ts
+++ b/packages/zone-js/dist/nativescript-globals.ts
@@ -1,0 +1,12 @@
+// Zone.__load_patch('nativescript_MutationObserver', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+//   api.patchClass('MutationObserver');
+//   api.patchClass('WebKitMutationObserver');
+// });
+
+// Zone.__load_patch('nativescript_IntersectionObserver', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+//   api.patchClass('IntersectionObserver');
+// });
+
+Zone.__load_patch('nativescript_FileReader', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+  api.patchClass('FileReader');
+});

--- a/packages/zone-js/dist/pre-zone-polyfills.ts
+++ b/packages/zone-js/dist/pre-zone-polyfills.ts
@@ -1,3 +1,5 @@
-global['__Zone_disable_legacy'] = true;
-global['__Zone_disable_EventTarget'] = true;
-global['__Zone_disable_XHR'] = true;
+export const disabledPatches = ['legacy', 'EventTarget', 'XHR', 'MutationObserver', 'IntersectionObserver', 'FileReader'];
+
+for (const patch of disabledPatches) {
+  global[`__Zone_disable_${patch}`] = true;
+}


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/angular/blob/master/DevelopmentWorkflow.md#running-the-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
Zone uses a `for(prop in object)` to patch all class properties, but this doesn't work with es6 as class properties aren't enumerable. Since NativeScript is distributed in es6+ the FileReader polyfill doesn't get properly patched by zonejs

## What is the new behavior?
Use `Object.getOwnPropertyNames` instead, so FileReader is patched correctly.

Currently only MutationObserver, WebKitMutationObserver, IntersectionObserver, FileReader and legacy XMLHttpRequest  are patched this way. Of all of them, only FileReader is polyfilled by NativeScript (the legacy XMLHttpRequest patch is already disabled)

Fixes #14.

