### PR TITLE
Dialog fixes

### DIFF
--- a/apps/nativescript-demo-ng/src/app/modal/modal.component.html
+++ b/apps/nativescript-demo-ng/src/app/modal/modal.component.html
@@ -1,3 +1,4 @@
-<GridLayout backgroundColor="blue" padding="20" width="100%" height="100%">
-  <Label [nativeDialogClose]="'thanks for clicking modal ' + id" text="in modal" color="white" fontSize="20"></Label>
+<GridLayout backgroundColor="blue" columns="*,*" padding="20" width="100%" height="100%">
+  <Button col="0" [nativeDialogClose]="'thanks for clicking modal ' + id" text="Close modal" fontSize="20"></Button>
+  <Button col="1" (tap)="openNewModal()" text="Open new modal" fontSize="20"></Button>
 </GridLayout>

--- a/apps/nativescript-demo-ng/src/app/modal/modal.component.ts
+++ b/apps/nativescript-demo-ng/src/app/modal/modal.component.ts
@@ -1,14 +1,21 @@
-import { Component, Inject, Optional } from '@angular/core';
-import { NativeDialogRef } from '@nativescript/angular';
+import { Component, Inject, OnDestroy, OnInit, Optional, ViewContainerRef } from '@angular/core';
+import { ModalDialogService, NativeDialogRef, NativeDialogService } from '@nativescript/angular';
 
 @Component({
   selector: 'ns-modal',
   templateUrl: `./modal.component.html`,
 })
-export class ModalComponent {
+export class ModalComponent implements OnInit, OnDestroy {
   id = Math.floor(Math.random() * 1000);
 
-  constructor(@Optional() ref: NativeDialogRef<ModalComponent>) {}
+  constructor(@Optional() private ref: NativeDialogRef<ModalComponent>, private nativeDialog: NativeDialogService, private modalDialog: ModalDialogService, private vcRef: ViewContainerRef) {}
+
+  openNewModal() {
+    this.nativeDialog.open(ModalComponent);
+    // this.modalDialog.showModal(ModalComponent, {
+    //   viewContainerRef: this.vcRef
+    // });
+  }
   ngOnInit() {
     console.log('modal init');
   }

--- a/packages/angular/src/lib/legacy/directives/dialogs.ts
+++ b/packages/angular/src/lib/legacy/directives/dialogs.ts
@@ -140,7 +140,7 @@ export class ModalDialogService {
       ɵmarkDirty(componentRef.instance);
       componentViewRef = new NgViewRef(componentRef);
       if (componentViewRef !== componentRef.location.nativeElement) {
-        componentRef.location.nativeElement._ngDialogRoot = componentViewRef;
+        componentRef.location.nativeElement._ngDialogRoot = componentViewRef.firstNativeLikeView;
       }
       // if we don't detach the view from its parent, ios gets mad
       componentViewRef.detachNativeLikeView();

--- a/packages/angular/src/lib/views/utils.ts
+++ b/packages/angular/src/lib/views/utils.ts
@@ -29,9 +29,6 @@ export function getFirstNativeLikeView(view: View, extractFromNSParent = false) 
     }
     return getFirstNativeLikeView(view.getChildAt(0));
   }
-  if (isContentView(view)) {
-    return getFirstNativeLikeView(view.content);
-  }
 
   if (extractFromNSParent) {
     // const node = view.parentNode;


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/angular/blob/master/DevelopmentWorkflow.md#running-the-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
NgViewRef would treat ContentView as a non-native view, but it has a native view associated by default.

Nested legacy dialogs using viewContainerRef would fail to open due to setting the wrong _ngDialogRoot

## What is the new behavior?
We no longer ignore ContentView and _ngDialogRoot now correctly points to the correct view.



**This PR doesn't need to be squashed**


Fixes #17.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

