### PR TITLE
fix(list-view): try to unwrap component views

### DIFF
--- a/packages/angular/src/lib/cdk/list-view/list-view.component.ts
+++ b/packages/angular/src/lib/cdk/list-view/list-view.component.ts
@@ -212,7 +212,10 @@ export class ListViewComponent<T = any> implements DoCheck, OnDestroy, AfterCont
         NativeScriptDebug.listViewLog(`onItemLoading: ${index} - Reusing existing view`);
       }
 
-      const templateKey = this._viewToTemplate.get(args.view);
+      let templateKey = this._viewToTemplate.get(args.view);
+      if (!templateKey && args.view instanceof LayoutBase && args.view.getChildrenCount() > 0) {
+        templateKey = this._viewToTemplate.get(args.view.getChildAt(0));
+      }
       if (!templateKey) {
         // this template was not created by us
         if (NativeScriptDebug.isLogEnabled()) {


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/angular/blob/master/DevelopmentWorkflow.md#running-the-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
If using a component without a native layout wrapper (stacklayout/etc), {N}'s listview will wrap the component in a layout. Doing so will break change detection

## What is the new behavior?
We try to unwrap the view to fetch the stored template key

Fixes #30.