### PR TITLE
fix: skip ChildrenOutLetContexts destroy hook if outlet has been changed

### DIFF
--- a/packages/angular/src/lib/legacy/router/page-router-outlet.ts
+++ b/packages/angular/src/lib/legacy/router/page-router-outlet.ts
@@ -151,7 +151,7 @@ export class PageRouterOutlet implements OnDestroy {
     // In the event that the `parentContexts` has changed the outlet
     // via the creation of another outlet, the `onChildOutletDestroyed`
     // will be skipped
-    if (this.parentContexts.getContext(this.name).outlet === <any>this) {
+    if (this.parentContexts.getContext(this.name)?.outlet === <any>this) {
       // Clear accumulated modal view page cache when page-router-outlet
       // destroyed on modal view closing
       this.parentContexts.onChildOutletDestroyed(this.name);

--- a/packages/angular/src/lib/legacy/router/page-router-outlet.ts
+++ b/packages/angular/src/lib/legacy/router/page-router-outlet.ts
@@ -148,9 +148,14 @@ export class PageRouterOutlet implements OnDestroy {
   }
 
   ngOnDestroy(): void {
-    // Clear accumulated modal view page cache when page-router-outlet
-    // destroyed on modal view closing
-    this.parentContexts.onChildOutletDestroyed(this.name);
+    // In the event that the `parentContexts` has changed the outlet
+    // via the creation of another outlet, the `onChildOutletDestroyed`
+    // will be skipped
+    if (this.parentContexts.getContext(this.name).outlet === <any>this) {
+      // Clear accumulated modal view page cache when page-router-outlet
+      // destroyed on modal view closing
+      this.parentContexts.onChildOutletDestroyed(this.name);
+    }
 
     if (this.outlet) {
       this.outlet.outletKeys.forEach((key) => {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/angular/blob/master/DevelopmentWorkflow.md#running-the-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
The `page-router-outlet` will stop working if a call with `clearHistory: true` was invoked prior

## What is the new behavior?
The `page-router-outlet` continues to work and respond to navigations even if `clearHistory: true` is called

fixes: #39