### PR TITLE
fix: use new import.meta.webpackHmr to account for esm

### DIFF
--- a/packages/angular/src/lib/application.ts
+++ b/packages/angular/src/lib/application.ts
@@ -62,8 +62,8 @@ export interface AppRunOptions<T, K> {
   launchView?: (reason: NgModuleReason) => AppLaunchView;
 }
 
-if (module['hot']) {
-  module['hot'].decline();
+if (import.meta['webpackHot']) {
+  import.meta['webpackHot'].decline();
   global.__onLiveSyncCore = () => {
     Application.getRootView()?._onCssStateChange();
     // all other changes are applied by runNativeScriptAngularApp
@@ -394,7 +394,7 @@ export function runNativeScriptAngularApp<T, K>(options: AppRunOptions<T, K>) {
   if (oldAddEventListener) {
     global.NativeScriptGlobals.events.addEventListener = oldAddEventListener;
   }
-  if (module['hot']) {
+  if (import.meta['webpackHot']) {
     // handle HMR Application.run
     global['__dispose_app_ng_platform__'] = () => {
       disposePlatform('hotreload');


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/angular/blob/master/DevelopmentWorkflow.md#running-the-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
Sometimes with angular 13 hmr will trigger a restart instead of a reload due to `module['hot']` not being replaced by webpack.

## What is the new behavior?
We use the new esm import.meta to get that information.

