### PR TITLE
fix: restrict nested outlet back navigation scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# @nativescript/angular 12+
+# @nativescript/angular
 
-For usage with NativeScript for Angular 12+ projects.
+For usage with NativeScript for Angular 12+ (13, etc.) projects.
 
 Clean and setup workspace:
 

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -1,3 +1,3 @@
 # @nativescript/angular
 
-NativeScript for Angular v12+
+For usage with NativeScript for Angular 12+ (13, etc.) projects.

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nativescript/angular",
-  "version": "13.0.1",
+  "version": "13.0.2-alpha.0",
   "homepage": "https://nativescript.org/",
   "repository": {
     "type": "git",

--- a/packages/angular/src/lib/legacy/router/ns-location-strategy.ts
+++ b/packages/angular/src/lib/legacy/router/ns-location-strategy.ts
@@ -266,7 +266,7 @@ export class NSLocationStrategy extends LocationStrategy {
   }
 
   // Methods for syncing with page navigation in PageRouterOutlet
-  public _beginBackPageNavigation(frame: Frame) {
+  public _beginBackPageNavigation(frame: Frame, outletKey: string) {
     const outlet: Outlet = this.getOutletByFrame(frame);
 
     if (!outlet || outlet.isPageNavigationBack) {
@@ -279,7 +279,8 @@ export class NSLocationStrategy extends LocationStrategy {
     if (NativeScriptDebug.isLogEnabled()) {
       NativeScriptDebug.routerLog('NSLocationStrategy.startGoBack()');
     }
-    outlet.isPageNavigationBack = true;
+    outlet.setOutletKeyNavigatingBack(outletKey);
+    // outlet.isPageNavigationBack = true;
     // we find all the children and also set their isPageNavigationBack
     this.outlets
       .filter((o) => {

--- a/packages/angular/src/lib/legacy/router/ns-location-utils.ts
+++ b/packages/angular/src/lib/legacy/router/ns-location-utils.ts
@@ -61,6 +61,15 @@ export class Outlet {
     this.path = path;
   }
 
+  setOutletKeyNavigatingBack(key: string) {
+    const nests = key.split('/');
+    this.outletKeys
+      .filter((k) => k.split('/').length >= nests.length)
+      .forEach((k) => {
+        this._navigatingBackOutlets.add(k);
+      });
+  }
+
   containsFrame(frame: Frame): boolean {
     return this.frames.indexOf(frame) > -1;
   }

--- a/packages/angular/src/lib/legacy/router/page-router-outlet.ts
+++ b/packages/angular/src/lib/legacy/router/page-router-outlet.ts
@@ -327,9 +327,12 @@ export class PageRouterOutlet implements OnDestroy {
     // Add it to the new page
     this.viewUtil.appendChild(page, componentView);
 
+    const topActivatedRoute = findTopActivatedRouteNodeForOutlet(this._activatedRoute.snapshot);
+    const outletKey = this.locationStrategy.getRouteFullPath(topActivatedRoute);
+
     const navigatedFromCallback = (<any>global).Zone.current.wrap((args: NavigatedData) => {
       if (args.isBackNavigation) {
-        this.locationStrategy._beginBackPageNavigation(this.frame);
+        this.locationStrategy._beginBackPageNavigation(this.frame, outletKey);
         this.locationStrategy.back(null, this.frame);
       }
     });


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/angular/blob/master/DevelopmentWorkflow.md#running-the-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
We mark all outlet keys as being backed on.

## What is the new behavior?
We only mark keys that are of a higher nesting level than the current key as being backed on.


Fixes #49.
