### PR TITLE
fix: clear all history keys for outlet

### DIFF
--- a/packages/angular/src/lib/legacy/router/page-router-outlet.ts
+++ b/packages/angular/src/lib/legacy/router/page-router-outlet.ts
@@ -370,7 +370,10 @@ export class PageRouterOutlet implements OnDestroy {
       const clearCallback = () =>
         setTimeout(() => {
           if (this.outlet) {
-            this.routeReuseStrategy.clearCache(this.outlet.outletKeys[0]);
+            // potential alternative fix (only fix children of the current outlet)
+            // const nests = outletKey.split('/');
+            // this.outlet.outletKeys.filter((k) => k.split('/').length >= nests.length).forEach((key) => this.routeReuseStrategy.clearCache(key));
+            this.outlet.outletKeys.forEach((key) => this.routeReuseStrategy.clearCache(key));
           }
         });
 


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/angular/blob/master/DevelopmentWorkflow.md#running-the-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
We're only deleting the cache for the parent outlet. Since angular 13 route reuse is now called to all children as well.

## What is the new behavior?
We clear all the outlet keys

Fixes #61.

