### PR TITLE
fix: patch showModal call in zone

### DIFF
--- a/packages/zone-js/dist/events.ts
+++ b/packages/zone-js/dist/events.ts
@@ -47,4 +47,23 @@ Zone.__load_patch('nativescript_dispatchToMainThread', (global, zone, api) => {
   );
 });
 
+Zone.__load_patch('nativescript_showModal', (global, zone, api) => {
+  api.patchMethod(
+    View.prototype,
+    'showModal',
+    (delegate, delegateName, name) =>
+      function (self, args) {
+        if (args.length === 2) {
+          const options = args[1];
+          if (options.closeCallback) {
+            options.closeCallback = Zone.current.wrap(options.closeCallback, 'NS showModal patch');
+          }
+        } else if (args.length > 3) {
+          args[3] = Zone.current.wrap(args[3], 'NS showModal patch');
+        }
+        return delegate.apply(self, args);
+      }
+  );
+});
+
 //! queueMacroTask should never be patched! We should consider it as a low level API to queue macroTasks which will be patched separately by other patches.


### PR DESCRIPTION


## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/angular/blob/master/DevelopmentWorkflow.md#running-the-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
the view showModal is not patched, so the close callback may not always return on the angular zone

## What is the new behavior?
We now patch the showModal method
