### PR TITLE
fix: better handling of parentNode on detached elements

### DIFF
--- a/packages/angular/src/lib/view-util.ts
+++ b/packages/angular/src/lib/view-util.ts
@@ -90,12 +90,9 @@ export class ViewUtil {
       // no previous or next, append to the parent
       previous = extendedParent.lastChild; // this can still be undefined if the parent has no children!
     }
-    // Note: handle case with listview nodes
-    if (extendedChild !== previous && extendedChild !== next) {
-      this.insertInList(extendedParent, extendedChild, previous, next);
-    }
+    this.insertInList(extendedParent, extendedChild, previous, next);
 
-    if (isInvisibleNode(child)) {
+    if (isDetachedElement(child) || isInvisibleNode(child)) {
       extendedChild.parentNode = extendedParent;
     }
 
@@ -212,6 +209,7 @@ export class ViewUtil {
 
     const extendedParent = this.ensureNgViewExtensions(parent);
     const extendedChild = this.ensureNgViewExtensions(child);
+    extendedChild.parentNode = null;
 
     this.removeFromList(extendedParent, extendedChild);
     if (!isDetachedElement(extendedChild)) {

--- a/packages/angular/src/lib/views/utils.ts
+++ b/packages/angular/src/lib/views/utils.ts
@@ -31,9 +31,9 @@ export function getFirstNativeLikeView(view: View, extractFromNSParent = false) 
   }
 
   if (extractFromNSParent) {
-    // const node = view.parentNode;
+    const node = view.parentNode;
     detachViewFromParent(view);
-    // view.parentNode = node;
+    view.parentNode = node;
   }
   return view;
 }


### PR DESCRIPTION
This is a better fix for the RadListView issue people have been facing (infinite loop hanging the UI). We now handle the parentNode for all detached elements, as well as keeping a parentNode reference to manually detached elements so angular can correctly find it in our "logical" view tree
