### PR TITLE
fix: modal beforeClosed and afterClosed consistency between platforms

### DIFF
--- a/packages/angular/src/lib/cdk/dialog/dialog-ref.ts
+++ b/packages/angular/src/lib/cdk/dialog/dialog-ref.ts
@@ -61,13 +61,14 @@ export class NativeDialogRef<T, R = any> {
       .subscribe(() => {
         clearTimeout(this._closeFallbackTimeout);
         this._finishDialogClose();
+        this._afterClosed.next(this._result);
+        this._afterClosed.complete();
       });
 
     _nativeModalRef.onDismiss.subscribe(() => {
       this._beforeClosed.next(this._result);
       this._beforeClosed.complete();
-      this._afterClosed.next(this._result);
-      this._afterClosed.complete();
+
       this.componentInstance = null!;
       _nativeModalRef.dispose();
     });
@@ -98,7 +99,11 @@ export class NativeDialogRef<T, R = any> {
         // amount of time plus 100ms. We don't need to run this outside the NgZone, because for the
         // vast majority of cases the timeout will have been cleared before it has the chance to fire.
         this._closeFallbackTimeout = setTimeout(
-          () => this._finishDialogClose(),
+          () => {
+            this._finishDialogClose();
+            this._afterClosed.next(this._result);
+            this._afterClosed.complete();
+          },
           //event.totalTime + 100);
           100
         );

--- a/packages/angular/src/lib/legacy/directives/dialogs.ts
+++ b/packages/angular/src/lib/legacy/directives/dialogs.ts
@@ -123,7 +123,7 @@ export class ModalDialogService {
     let detachedLoaderRef: ComponentRef<DetachedLoader>;
     let portalOutlet: NativeScriptDomPortalOutlet;
 
-    const closeCallback = once((...args) => {
+    const closeCallback = once(async (...args) => {
       options.doneCallback.apply(undefined, args);
       if (componentViewRef) {
         componentViewRef.firstNativeLikeView.closeModal();
@@ -131,7 +131,7 @@ export class ModalDialogService {
         if (this._closed$) {
           this._closed$.next(params);
         }
-        this.location._closeModalNavigation();
+        await this.location._closeModalNavigation();
         if (detachedLoaderRef || portalOutlet) {
           this.zone.run(() => {
             portalOutlet?.dispose();

--- a/packages/angular/src/lib/legacy/router/ns-location-strategy.ts
+++ b/packages/angular/src/lib/legacy/router/ns-location-strategy.ts
@@ -354,6 +354,8 @@ export class NSLocationStrategy extends LocationStrategy {
       this.currentOutlet = outlet;
       this.currentOutlet.showingModal = false;
       this.callPopState(this.currentOutlet.peekState(), false);
+      // this is needed because angular does a setTimeout on onPopState, so if we don't do this we might end up with inconsistent state
+      return new Promise((resolve) => setTimeout(resolve, 0));
     }
   }
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/angular/blob/master/DevelopmentWorkflow.md#running-the-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
Currently when a modal closes the events fire quickly, often before the modal has fully closed. As a result, navigations done directly on the afterClosed callback won't work, needing a 0ms delay on iOS and >100ms on Android.

## What is the new behavior?
We delay the afterClosed callback until we're sure the modal has fully closed

