### PR TITLE
fix: use changeDetectorRef.detectChanges() instead of detectChanges() private api

### DIFF
--- a/packages/angular/src/lib/cdk/dialog/native-modal-ref.ts
+++ b/packages/angular/src/lib/cdk/dialog/native-modal-ref.ts
@@ -1,15 +1,15 @@
-import { ApplicationRef, ComponentFactoryResolver, ComponentRef, EmbeddedViewRef, Injector, Optional, ViewContainerRef, ɵdetectChanges as detectChanges } from '@angular/core';
-import { ContentView, View, Application, Frame } from '@nativescript/core';
+import { ApplicationRef, ComponentFactoryResolver, ComponentRef, EmbeddedViewRef, Injector, Optional, ViewContainerRef } from '@angular/core';
+import { Application, ContentView, Frame, View } from '@nativescript/core';
 import { fromEvent, Subject } from 'rxjs';
 import { take } from 'rxjs/operators';
 import { AppHostAsyncView, AppHostView } from '../../app-host-view';
 import { NSLocationStrategy } from '../../legacy/router/ns-location-strategy';
 import { once } from '../../utils/general';
+import { NgViewRef } from '../../view-refs';
 import { DetachedLoader } from '../detached-loader';
 import { ComponentPortal, TemplatePortal } from '../portal/common';
 import { NativeScriptDomPortalOutlet } from '../portal/nsdom-portal-outlet';
 import { NativeDialogConfig } from './dialog-config';
-import { NgViewRef } from '../../view-refs';
 
 export class NativeModalRef {
   _id: string;
@@ -103,7 +103,7 @@ export class NativeModalRef {
     const targetView = new ContentView();
     this.portalOutlet = new NativeScriptDomPortalOutlet(targetView, this._config.componentFactoryResolver || this._injector.get(ComponentFactoryResolver), this._injector.get(ApplicationRef), this._injector);
     const componentRef = this.portalOutlet.attach(portal);
-    detectChanges(componentRef.instance);
+    componentRef.changeDetectorRef.detectChanges();
     this.modalViewRef = new NgViewRef(componentRef);
     if (this.modalViewRef.firstNativeLikeView !== this.modalViewRef.view) {
       (<any>this.modalViewRef.view)._ngDialogRoot = this.modalViewRef.firstNativeLikeView;

--- a/packages/angular/src/lib/legacy/directives/dialogs.ts
+++ b/packages/angular/src/lib/legacy/directives/dialogs.ts
@@ -1,4 +1,4 @@
-import { ApplicationRef, ComponentFactoryResolver, ComponentRef, Injectable, Injector, NgModuleRef, NgZone, Type, ViewContainerRef, ɵdetectChanges as detectChanges } from '@angular/core';
+import { ApplicationRef, ComponentFactoryResolver, ComponentRef, Injectable, Injector, NgModuleRef, NgZone, Type, ViewContainerRef } from '@angular/core';
 import { Application, ContentView, Frame, ShowModalOptions, View, ViewBase } from '@nativescript/core';
 import { Subject } from 'rxjs';
 import { AppHostAsyncView, AppHostView } from '../../app-host-view';
@@ -169,7 +169,7 @@ export class ModalDialogService {
       const portal = new ComponentPortal(options.type);
       portalOutlet = new NativeScriptDomPortalOutlet(targetView, options.resolver, this.appRef, childInjector);
       const componentRef = portalOutlet.attach(portal);
-      detectChanges(componentRef.instance);
+      componentRef.changeDetectorRef.detectChanges();
       componentViewRef = new NgViewRef(componentRef);
       if (options.useContextAsComponentProps && options.context) {
         for (const key in options.context) {


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/angular/blob/master/DevelopmentWorkflow.md#running-the-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
Turns out that the `detectChanges` doesn't actually detect changes (or maybe rather doesn't mark the component for change detection)

## What is the new behavior?
We force the change detection via `changeDetectorRef.detectChanges()`, which solves a few issues with CD being run AFTER the view is created and attached

