### PR TITLE
fix: use inject in ListViewComponent

### DIFF
--- a/packages/angular/src/lib/cdk/list-view/list-view.component.ts
+++ b/packages/angular/src/lib/cdk/list-view/list-view.component.ts
@@ -1,4 +1,4 @@
-import { AfterContentInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ContentChild, Directive, DoCheck, ElementRef, EmbeddedViewRef, EventEmitter, forwardRef, Host, HostListener, Inject, InjectionToken, Input, IterableDiffer, IterableDiffers, OnDestroy, Output, TemplateRef, ViewChild, ViewContainerRef, ɵisListLikeIterable as isListLikeIterable } from '@angular/core';
+import { AfterContentInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ContentChild, Directive, DoCheck, ElementRef, EmbeddedViewRef, EventEmitter, forwardRef, Host, HostListener, inject, Inject, InjectionToken, Input, IterableDiffer, IterableDiffers, NgZone, OnDestroy, Output, TemplateRef, ViewChild, ViewContainerRef, ɵisListLikeIterable as isListLikeIterable } from '@angular/core';
 import { ItemEventData, KeyedTemplate, LayoutBase, ListView, ObservableArray, profile, View } from '@nativescript/core';
 
 import { extractSingleViewRecursive } from '../../element-registry/registry';
@@ -96,7 +96,12 @@ export class ListViewComponent<T = any> implements DoCheck, OnDestroy, AfterCont
     return this.templatedItemsView;
   }
 
-  protected templatedItemsView: ListView;
+  private readonly _iterableDiffers: IterableDiffers = inject(IterableDiffers);
+  private readonly _changeDetectorRef: ChangeDetectorRef = inject(ChangeDetectorRef);
+  private readonly _elementRef: ElementRef = inject(ElementRef);
+
+  // I believe this only exists so this can be inherited and people can override it.
+  protected templatedItemsView: ListView = this._elementRef.nativeElement;
   protected _items: T[] | ObservableArray<T>;
   protected _differ: IterableDiffer<T>;
   protected _templateMap: Map<string, NsTemplatedItem<T>>;
@@ -130,8 +135,24 @@ export class ListViewComponent<T = any> implements DoCheck, OnDestroy, AfterCont
     this.templatedItemsView.items = this._items;
   }
 
-  constructor(_elementRef: ElementRef, private readonly _iterableDiffers: IterableDiffers, private readonly _changeDetectorRef: ChangeDetectorRef) {
-    this.templatedItemsView = _elementRef.nativeElement;
+  /**
+   * @deprecated
+   */
+  constructor(_elementRef: ElementRef);
+  /**
+   * @deprecated
+   */
+  constructor(_elementRef: ElementRef, _iterableDiffers: IterableDiffers, _changeDetectorRef: ChangeDetectorRef);
+  /**
+   * @deprecated
+   */
+  constructor(_elementRef: ElementRef, _iterableDiffers: IterableDiffers, _ngZone: NgZone);
+  constructor();
+  // this elementRef is only here for backwards compatibility reasons
+  constructor(_elementRef?: ElementRef) {
+    if (_elementRef) {
+      this.templatedItemsView = _elementRef.nativeElement;
+    }
   }
 
   ngAfterContentInit() {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/angular/blob/master/DevelopmentWorkflow.md#running-the-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
We changed the ListViewComponent a while ago and it broke backwards compatibility for some plugins

## What is the new behavior?
We don't rely on `super()` calls anymore and instead use `inject()`


