### PR TITLE
feat: allow providing custom dialog view

### DIFF
--- a/packages/angular/src/lib/cdk/dialog/dialog-config.ts
+++ b/packages/angular/src/lib/cdk/dialog/dialog-config.ts
@@ -7,7 +7,7 @@
  */
 
 import { ViewContainerRef, ComponentFactoryResolver } from '@angular/core';
-import { ShowModalOptions } from '@nativescript/core';
+import { ShowModalOptions, View } from '@nativescript/core';
 
 export type NativeShowModalOptions = Partial<Omit<ShowModalOptions, 'cancelable' | 'closeCallback'>>;
 /**
@@ -21,6 +21,9 @@ export class NativeDialogConfig<D = any> {
    * content will be rendered.
    */
   viewContainerRef?: ViewContainerRef;
+
+  /** Where to render the actual dialog in. By default it renders using the native view of the ViewContainerRef */
+  renderIn: 'root' | 'viewContainerRef' | View = 'viewContainerRef';
 
   /** ID for the dialog. If omitted, a unique one will be generated. */
   id?: string;

--- a/packages/angular/src/lib/cdk/dialog/native-modal-ref.ts
+++ b/packages/angular/src/lib/cdk/dialog/native-modal-ref.ts
@@ -24,8 +24,13 @@ export class NativeModalRef {
   private _closeCallback: () => void;
   private _isDismissed = false;
 
-  constructor(private _config: NativeDialogConfig, private _injector: Injector, @Optional() private location?: NSLocationStrategy) {
-    let parentView = this._config.viewContainerRef?.element.nativeElement || Application.getRootView();
+  constructor(
+    private _config: NativeDialogConfig,
+    private _injector: Injector,
+    @Optional() private location?: NSLocationStrategy,
+  ) {
+    const nativeElement = this._config.renderIn === 'root' ? Application.getRootView() : this._config.renderIn === 'viewContainerRef' ? this._config.viewContainerRef?.element.nativeElement : this._config.renderIn;
+    let parentView = nativeElement || Application.getRootView();
 
     if ((parentView instanceof AppHostView || parentView instanceof AppHostAsyncView) && parentView.ngAppRoot) {
       parentView = parentView.ngAppRoot;


### PR DESCRIPTION
Allows providing a custom dialog view to render the dialog. Useful when you want to pass the viewcontainerref but don't want the dialog to be constructed in that place