### PR TITLE
feat: allow tracking of dom changes and preventing events from firing during one

### DIFF
--- a/packages/angular/src/lib/public_api.ts
+++ b/packages/angular/src/lib/public_api.ts
@@ -25,7 +25,7 @@ export * from './detached-loader-utils';
 export { AppLaunchView, AppRunOptions, NgModuleEvent, NgModuleReason, disableRootViewHanding, onAfterLivesync, onBeforeLivesync, postAngularBootstrap$, preAngularDisposal$, runNativeScriptAngularApp, ApplicationConfig, bootstrapApplication } from './application';
 export * from './element-registry';
 export * from './nativescript-xhr-factory';
-export { EmulatedRenderer, NativeScriptRendererFactory, COMPONENT_VARIABLE as ɵCOMPONENT_VARIABLE, CONTENT_ATTR as ɵCONTENT_ATTR, HOST_ATTR as ɵHOST_ATTR } from './nativescript-renderer';
+export { EmulatedRenderer, NativeScriptRendererFactory, COMPONENT_VARIABLE as ɵCOMPONENT_VARIABLE, CONTENT_ATTR as ɵCONTENT_ATTR, HOST_ATTR as ɵHOST_ATTR, NativeScriptRendererHelperService } from './nativescript-renderer';
 export * from './utils';
 export * from './forms';
 export * from './animations';

--- a/packages/angular/src/lib/tokens.ts
+++ b/packages/angular/src/lib/tokens.ts
@@ -22,3 +22,6 @@ export const PAGE_FACTORY = new InjectionToken<PageFactory>('NativeScriptPageFac
 export const defaultPageFactory: PageFactory = function (_opts: PageFactoryOptions) {
   return new Page();
 };
+
+export const PREVENT_CHANGE_EVENTS_DURING_CD = new InjectionToken<boolean>('NativeScriptPreventChangeEventsDuringCd');
+export const PREVENT_SPECIFIC_EVENTS_DURING_CD = new InjectionToken<string[]>('NativeScriptPreventSpecificEventsDuringCd');

--- a/packages/angular/src/lib/utils/native-element-host.ts
+++ b/packages/angular/src/lib/utils/native-element-host.ts
@@ -1,0 +1,37 @@
+import { Type, reflectComponentType } from '@angular/core';
+import { GridLayout, View } from '@nativescript/core';
+import { registerElement } from '../element-registry/registry';
+
+function createClass<T extends { new (...args: any[]): any }>(className: string, extendsClassName: T) {
+  return { [className]: class extends extendsClassName {} }[className];
+}
+
+export function NativeElementHost(
+  fn: () => typeof View,
+  {
+    forcedSelector,
+    createProxyClass = true,
+  }: {
+    forcedSelector?: string;
+    createProxyClass?: boolean;
+  } = {},
+) {
+  return function <T extends Type<any>>(v: T) {
+    ((forcedSelector || reflectComponentType(v)?.selector)?.split(',') || [])
+      .map((v) => v.trim())
+      .filter((v) => !v.includes('['))
+      .forEach((selector) => {
+        if (createProxyClass) {
+          let cachedCls: typeof View;
+          registerElement(selector, () => {
+            if (!cachedCls) {
+              cachedCls = createClass(selector, fn() as any);
+            }
+            return cachedCls;
+          });
+        } else {
+          registerElement(selector, fn);
+        }
+      });
+  };
+}


### PR DESCRIPTION
This is a draft PR with a small change that would allow the user to prevent some events from firing during a DOM change (example: during change detection), so such events would only reach angular if they fire outside of CD (eg: during user interaction)