### PR TITLE
feat: make nativescript identify as browser in angular

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -16,7 +16,7 @@
     "Angular"
   ],
   "dependencies": {
-    "@nativescript/zone-js": "^3.0.0"
+    "@nativescript/zone-js": "^3.0.4"
   },
   "sideEffects": [
     "**/nativescript-angular-polyfills.mjs",

--- a/packages/angular/src/lib/platform-nativescript.ts
+++ b/packages/angular/src/lib/platform-nativescript.ts
@@ -1,4 +1,4 @@
-import { Type, Injector, CompilerOptions, PlatformRef, NgModuleFactory, NgModuleRef, EventEmitter, Sanitizer, InjectionToken, StaticProvider, createPlatformFactory, platformCore } from '@angular/core';
+import { Type, Injector, CompilerOptions, PlatformRef, NgModuleFactory, NgModuleRef, EventEmitter, Sanitizer, InjectionToken, StaticProvider, createPlatformFactory, platformCore, PLATFORM_ID } from '@angular/core';
 import { DOCUMENT } from '@angular/common';
 import { NativeScriptPlatformRefProxy } from './platform-ref';
 import { AppHostView } from './app-host-view';
@@ -31,7 +31,7 @@ export class NativeScriptDocument {
   }
 }
 
-export const COMMON_PROVIDERS = [defaultPageFactoryProvider, { provide: Sanitizer, useClass: NativeScriptSanitizer, deps: [] }, { provide: DOCUMENT, useClass: NativeScriptDocument, deps: [] }];
+export const COMMON_PROVIDERS = [defaultPageFactoryProvider, { provide: Sanitizer, useClass: NativeScriptSanitizer, deps: [] }, { provide: DOCUMENT, useClass: NativeScriptDocument, deps: [] }, { provide: PLATFORM_ID, useValue: 'browser' }];
 
 export const platformNativeScript = createPlatformFactory(platformCore, 'nativescriptDynamic', COMMON_PROVIDERS);
 


### PR DESCRIPTION
This enables all the browser features like `@defer`, `afterRender` and `afterNextRender`, which are integral parts of new updates (including the angular router in the future)

BREAKING CHANGES:

Identifying as browser can have minor impact on existing libraries that use that to manipulate the DOM. So far, the usage inside angular itself is minimal enough that it shouldn't impact apps other than enabling previously mentioned features.
