### PR TITLE
feat: default zoneless polyfill setup

### DIFF
--- a/apps/nativescript-demo-ng/src/polyfills.ts
+++ b/apps/nativescript-demo-ng/src/polyfills.ts
@@ -11,10 +11,10 @@ import '@nativescript/angular/polyfills';
  * Zone.js and patches
  */
 // Add pre-zone.js patches needed for the NativeScript platform
-import '@nativescript/zone-js/dist/pre-zone-polyfills';
+// import '@nativescript/zone-js/dist/pre-zone-polyfills';
 
-// Zone JS is required by default for Angular itself
-import 'zone.js';
+// // Zone JS is required by default for Angular itself
+// import 'zone.js';
 
-// Add NativeScript specific Zone JS patches
-import '@nativescript/zone-js';
+// // Add NativeScript specific Zone JS patches
+// import '@nativescript/zone-js';

--- a/packages/angular/polyfills/src/index.ts
+++ b/packages/angular/polyfills/src/index.ts
@@ -30,3 +30,5 @@ const polyfilledPerformance = getPerformanceObject();
 for (const key in polyfilledPerformance) {
   global.performance[key] ??= polyfilledPerformance[key];
 }
+
+global.queueMicrotask ??= (fn: () => unknown) => Promise.resolve().then(fn);


### PR DESCRIPTION
- Adjusts polyfills to not include zone at all
- Provides `queueMicrotask` polyfill needed for angular in general (this could be done at runtime level)

Provide guidance on conditionally enabling zoneless or not but using setups as shown here.