### PR TITLE
fix: answer DOM probes on NativeScriptDocument instead of throwing

### DIFF
--- a/packages/angular/src/lib/nativescript.ts
+++ b/packages/angular/src/lib/nativescript.ts
@@ -1,5 +1,5 @@
 import { IMAGE_CONFIG, ViewportScroller, XhrFactory, ɵNullViewportScroller as NullViewportScroller } from '@angular/common';
-import { ApplicationModule, ErrorHandler, Inject, NgModule, NO_ERRORS_SCHEMA, Optional, Provider, RendererFactory2, SkipSelf, StaticProvider, ɵINJECTOR_SCOPE as INJECTOR_SCOPE } from '@angular/core';
+import { ApplicationModule, CSP_NONCE, ErrorHandler, Inject, NgModule, NO_ERRORS_SCHEMA, Optional, Provider, RendererFactory2, SkipSelf, StaticProvider, ɵINJECTOR_SCOPE as INJECTOR_SCOPE } from '@angular/core';
 import { Color, Device, View } from '@nativescript/core';
 import { AppHostView } from './app-host-view';
 import { NativescriptXhrFactory } from './nativescript-xhr-factory';
@@ -39,6 +39,10 @@ export const NATIVESCRIPT_MODULE_STATIC_PROVIDERS: StaticProvider[] = [
   { provide: NAMESPACE_FILTERS, useClass: PlatformNamespaceFilter, deps: [DEVICE], multi: true },
   { provide: DEVICE, useValue: Device },
   { provide: XhrFactory, useClass: NativescriptXhrFactory, deps: [] },
+  // No CSP in a NativeScript runtime. Providing it also stops the token's default
+  // factory reading `DOCUMENT.body.querySelector()`. Must stay root-scoped: the root
+  // injector resolves `providedIn: 'root'` tokens before consulting the platform.
+  { provide: CSP_NONCE, useValue: null },
 ];
 export const NATIVESCRIPT_MODULE_PROVIDERS: Provider[] = [
   { provide: ViewportScroller, useClass: NullViewportScroller },

--- a/packages/angular/src/lib/platform-nativescript.ts
+++ b/packages/angular/src/lib/platform-nativescript.ts
@@ -37,12 +37,41 @@ export class NativeScriptSanitizer extends Sanitizer {
 //   };
 // }
 
+/**
+ * Angular probes the DOM to discover optional configuration it may have been handed
+ * out of band - a `ngCspNonce` attribute on `<body>`, a transfer state `<script>` in
+ * the document. None of that can exist here, so the lookups answer "nothing found".
+ * Leaving the methods undefined instead surfaces as a `TypeError` thrown from deep
+ * inside framework code, since `document.body` is present and merely hollow.
+ */
+const NO_DOM_QUERIES = {
+  querySelector: () => null,
+  querySelectorAll: () => [],
+  getElementById: () => null,
+  getElementsByTagName: () => [],
+  getElementsByClassName: () => [],
+  getAttribute: () => null,
+  hasAttribute: () => false,
+};
+
 export class NativeScriptDocument {
   // Required by the AnimationDriver
   public body: any = {
     isOverride: true,
+    ...NO_DOM_QUERIES,
   };
 
+  public head: any = {
+    ...NO_DOM_QUERIES,
+  };
+
+  public querySelector = NO_DOM_QUERIES.querySelector;
+  public querySelectorAll = NO_DOM_QUERIES.querySelectorAll;
+  public getElementById = NO_DOM_QUERIES.getElementById;
+  public getElementsByTagName = NO_DOM_QUERIES.getElementsByTagName;
+  public getElementsByClassName = NO_DOM_QUERIES.getElementsByClassName;
+
+  // Deliberately still throws: constructing real nodes is a caller bug, not a probe.
   createElement(tag: string) {
     throw new Error('NativeScriptDocument is not DOM Document. There is no createElement() method.');
   }


### PR DESCRIPTION
## What

Angular discovers some optional configuration by reading the DOM. `NativeScriptDocument` exposed a `body` that was truthy but hollow (`{ isOverride: true }`), so those probes did not fall into their "not found" path — they threw.

The clearest case is `CSP_NONCE`, whose default factory is:

```ts
inject(DOCUMENT).body?.querySelector('[ngCspNonce]')?.getAttribute('ngCspNonce') || null
```

The `body?.` guard anticipates a missing `body`, not a `body` without `querySelector`, so this fails with `inject(...).body?.querySelector is not a function`.

Signal forms hit this on the very first `[formField]` binding: `FormField` injects the root `InputValidityMonitor`, whose default implementation (`AnimationInputValidityMonitor`) injects `CSP_NONCE` in a field initializer. The result is that **every signal-form dialog crashes at construction** on Angular 22. Note that `inject(CSP_NONCE, { optional: true })` does not help — `InjectionToken` defaults to `providedIn: 'root'`, so the token always resolves and the DOM-reading factory always runs.

## Changes

- `NativeScriptDocument` now answers DOM lookups with "nothing found" rather than leaving the methods undefined: `querySelector`, `querySelectorAll`, `getElementById`, `getElementsByTagName`, `getElementsByClassName` on the document itself, plus `body` and `head` (`getAttribute`/`hasAttribute` included there).
- `createElement` deliberately keeps throwing. Probing for optional config should degrade quietly; constructing real nodes is a caller bug and should stay loud.
- `CSP_NONCE` is provided as `null` in `NATIVESCRIPT_MODULE_STATIC_PROVIDERS`. There is no CSP in a NativeScript runtime, and providing it skips the DOM-reading factory entirely.

### Why `CSP_NONCE` must be a root provider

It is deliberately in `NATIVESCRIPT_MODULE_STATIC_PROVIDERS` (root scope) rather than `COMMON_PROVIDERS` (platform scope). `R3Injector.get()` checks its own records, then self-instantiates any `providedIn: 'root'` token whose scope it matches, and only then delegates to its parent. A platform-level provider is therefore never consulted. Verified empirically — see below.

## Verification

Ran Angular 22's real DI against both the old and new document shapes:

| Scenario | Result |
| --- | --- |
| Hollow `body`, no provider (status quo) | throws `inject(...).body?.querySelector is not a function` |
| Shim only | `null` |
| Root `CSP_NONCE` provider only | `null` |
| Both (this PR) | `null` |
| Platform-level `CSP_NONCE` provider | throws — confirms root scope is required |

The first row reproduces the reported crash string exactly.

`nx build angular` passes, and `packages/angular/src/lib/platform-nativescript.ts` is prettier-clean. `nativescript.ts` has pre-existing formatting drift that I left alone to keep the diff focused.

## Follow-up

This is the robust workaround. The cleaner fix belongs upstream: `InputValidityMonitor` is an abstract class whose provider is `{ providedIn: 'root', useClass: forwardRef(() => AnimationInputValidityMonitor) }` — an obvious platform seam that Angular's own tests already override — but the symbol is not exported. I have a companion Angular PR adding `ɵInputValidityMonitor` to `@angular/forms/signals`. Once that lands, `@nativescript/angular` can provide an inert monitor and never touch the DOM at all.
