### PR TITLE
fix: bootstrap NG0210 when the runtime exposes a global PerformanceObserver

### DIFF
--- a/apps/nativescript-demo-ng/src/tests/image-config.spec.ts
+++ b/apps/nativescript-demo-ng/src/tests/image-config.spec.ts
@@ -1,0 +1,20 @@
+import { IMAGE_CONFIG } from '@angular/common';
+import { TestBed } from '@angular/core/testing';
+import { NativeScriptModule } from '@nativescript/angular';
+
+describe('IMAGE_CONFIG', () => {
+  beforeEach(() => {
+    return TestBed.configureTestingModule({
+      imports: [NativeScriptModule],
+    }).compileComponents();
+  });
+
+  // Both flags are required: with either one unset, Angular reaches for `document` during
+  // bootstrap on any runtime that exposes a global PerformanceObserver.
+  it('disables both dev-mode image warnings', () => {
+    const config = TestBed.inject(IMAGE_CONFIG);
+
+    expect(config.disableImageSizeWarning).toBe(true);
+    expect(config.disableImageLazyLoadWarning).toBe(true);
+  });
+});

--- a/packages/angular/src/lib/nativescript.ts
+++ b/packages/angular/src/lib/nativescript.ts
@@ -1,4 +1,4 @@
-import { ViewportScroller, XhrFactory, ɵNullViewportScroller as NullViewportScroller } from '@angular/common';
+import { IMAGE_CONFIG, ViewportScroller, XhrFactory, ɵNullViewportScroller as NullViewportScroller } from '@angular/common';
 import { ApplicationModule, ErrorHandler, Inject, NgModule, NO_ERRORS_SCHEMA, Optional, Provider, RendererFactory2, SkipSelf, StaticProvider, ɵINJECTOR_SCOPE as INJECTOR_SCOPE } from '@angular/core';
 import { Color, Device, View } from '@nativescript/core';
 import { AppHostView } from './app-host-view';
@@ -40,7 +40,13 @@ export const NATIVESCRIPT_MODULE_STATIC_PROVIDERS: StaticProvider[] = [
   { provide: DEVICE, useValue: Device },
   { provide: XhrFactory, useClass: NativescriptXhrFactory, deps: [] },
 ];
-export const NATIVESCRIPT_MODULE_PROVIDERS: Provider[] = [{ provide: ViewportScroller, useClass: NullViewportScroller }];
+export const NATIVESCRIPT_MODULE_PROVIDERS: Provider[] = [
+  { provide: ViewportScroller, useClass: NullViewportScroller },
+  // Angular's dev-mode image warnings scan the DOM for <img> elements, which
+  // NativeScript has none of. Angular only skips them when both flags are set,
+  // and reaches for `document` as soon as a global PerformanceObserver exists.
+  { provide: IMAGE_CONFIG, useValue: { disableImageSizeWarning: true, disableImageLazyLoadWarning: true } },
+];
 
 @NgModule({
   imports: [ApplicationModule, DetachedLoader, NativeScriptCommonModule],


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. (No issue filed — found while updating an app to `@nativescript/ios` 9.1.0-alpha.20.)
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing. (The device suite was not run locally; CI runs it on both platforms.)
- [x] Tests for the changes are included.

## What is the current behavior?

Every debug boot fails on runtimes that ship a Web Performance API (e.g. `@nativescript/ios` 9.1.0-alpha.20, which does `g.PerformanceObserver = PerformanceObserver`):

```
NG0210: The document object is not available in this context.
Make sure the DOCUMENT injection token is provided.
    at getDocument (deps-bundle.mjs)
    at _ImagePerformanceWarning.start (deps-bundle.mjs)
```

Angular starts `ImagePerformanceWarning` at the end of `internalCreateApplication` whenever `ngDevMode` is on, and the service only bails out early in three cases:

```js
start() {
  if (ngServerMode || typeof PerformanceObserver === 'undefined' || (bothWarningsDisabled)) return;
  this.observer = this.initPerformanceObserver();
  const doc = getDocument();   // NG0210
```

The missing `PerformanceObserver` global is what used to keep this off our path. Once the runtime defines it, the service falls through to `getDocument()` — which reads a module-scoped variable set by Angular's internal `setDocument()`, not the `DOCUMENT` DI token we provide via `NativeScriptDocument` — and throws.

## What is the new behavior?

`NATIVESCRIPT_MODULE_PROVIDERS` now defaults `IMAGE_CONFIG` to disabling both image warnings, which restores the early return. That array feeds both `NativeScriptModule` and `createProvidersConfig`, so the NgModule and standalone bootstrap paths are both covered.

Both flags are required — Angular ANDs them. The provider has to live in the app/environment injector rather than `COMMON_PROVIDERS`, because `IMAGE_CONFIG` is declared `providedIn: 'root'` and the root environment injector self-satisfies it from the token's own factory instead of delegating to the platform injector.

The warnings scan the DOM for oversized and lazily-loaded `<img>` elements, so they can never produce a meaningful result under NativeScript. Apps that want them back can still provide their own `IMAGE_CONFIG` — app providers are applied after the NativeScript ones.

Verified against Angular 21.2.x and 22.0.x: the guard is identical in both, and `IMAGE_CONFIG` is public API on `@angular/common` in both.